### PR TITLE
Adding __attribute__ ((used)) fix

### DIFF
--- a/SoftI2CMaster.h
+++ b/SoftI2CMaster.h
@@ -87,34 +87,34 @@
 // Init function. Needs to be called once in the beginning.
 // Returns false if SDA or SCL are low, which probably means 
 // a I2C bus lockup or that the lines are not pulled up.
-boolean __attribute__ ((noinline)) i2c_init(void);
+boolean __attribute__ ((noinline)) i2c_init(void) __attribute__ ((used));
 
 // Start transfer function: <addr> is the 8-bit I2C address (including the R/W
 // bit). 
 // Return: true if the slave replies with an "acknowledge", false otherwise
-bool __attribute__ ((noinline)) i2c_start(uint8_t addr); 
+bool __attribute__ ((noinline)) i2c_start(uint8_t addr) __attribute__ ((used));
 
 // Similar to start function, but wait for an ACK! Be careful, this can 
 // result in an infinite loop!
-void  __attribute__ ((noinline)) i2c_start_wait(uint8_t addr);
+void  __attribute__ ((noinline)) i2c_start_wait(uint8_t addr) __attribute__ ((used));
 
 // Repeated start function: After having claimed the bus with a start condition,
 // you can address another or the same chip again without an intervening 
 // stop condition.
 // Return: true if the slave replies with an "acknowledge", false otherwise
-bool __attribute__ ((noinline)) i2c_rep_start(uint8_t addr);
+bool __attribute__ ((noinline)) i2c_rep_start(uint8_t addr) __attribute__ ((used));
 
 // Issue a stop condition, freeing the bus.
-void __attribute__ ((noinline)) i2c_stop(void) asm("ass_i2c_stop");
+void __attribute__ ((noinline)) i2c_stop(void) asm("ass_i2c_stop") __attribute__ ((used));
 
 // Write one byte to the slave chip that had been addressed
 // by the previous start call. <value> is the byte to be sent.
 // Return: true if the slave replies with an "acknowledge", false otherwise
-bool __attribute__ ((noinline)) i2c_write(uint8_t value) asm("ass_i2c_write");
+bool __attribute__ ((noinline)) i2c_write(uint8_t value) asm("ass_i2c_write") __attribute__ ((used));
  
 // Read one byte. If <last> is true, we send a NAK after having received 
 // the byte in order to terminate the read sequence. 
-uint8_t __attribute__ ((noinline)) i2c_read(bool last);
+uint8_t __attribute__ ((noinline)) i2c_read(bool last) __attribute__ ((used));
 
 // You can set I2C_CPUFREQ independently of F_CPU if you 
 // change the CPU frequency on the fly. If you do not define it,
@@ -201,8 +201,8 @@ uint8_t __attribute__ ((noinline)) i2c_read(bool last);
 
  
 // Internal delay functions.
-void __attribute__ ((noinline)) i2c_delay_half(void) asm("ass_i2c_delay_half");
-void __attribute__ ((noinline)) i2c_wait_scl_high(void) asm("ass_i2c_wait_scl_high");
+void __attribute__ ((noinline)) i2c_delay_half(void) asm("ass_i2c_delay_half") __attribute__ ((used));
+void __attribute__ ((noinline)) i2c_wait_scl_high(void) asm("ass_i2c_wait_scl_high") __attribute__ ((used));
 
 void  i2c_delay_half(void)
 { // function call 3 cycles => 3C


### PR DESCRIPTION
Adding __attribute__ ((used)) to lines where a function was declared using __attribute__ ((noinline)) originally. This was causing compile errors in newer versions of the Arduino IDE (>1.6.10). Compiles successfully in Arduino 1.8.1 on Mac after applying this fix. Based on the suggested fix in the original library found at https://github.com/felias-fogg/SoftI2CMaster